### PR TITLE
Fix Android Extreme2 startup and single-tap touch input

### DIFF
--- a/bop.nvgt
+++ b/bop.nvgt
@@ -8,10 +8,84 @@
 int bopit_index=0;
 bopit@[] bopits(0);
 touch_gesture_manager touch;
+class single_tap_touch_keyboard_interface : touch_keyboard_interface
+{
+dictionary tap_map;
+timer single_tap_guard;
+timer pending_release_timer;
+int[] pending_release_keys;
+bool has_pending_release=false;
+single_tap_touch_keyboard_interface(touch_gesture_manager@ parent, dictionary@ map, float minx = TOUCH_UNCOORDINATED, float maxx = TOUCH_UNCOORDINATED, float miny = TOUCH_UNCOORDINATED, float maxy = TOUCH_UNCOORDINATED)
+{
+super(parent, map, minx, maxx, miny, maxy);
+this.tap_map=map;
+}
+bool attempt_single_tap(uint finger_count, int[] &out key_codes)
+{
+int key;
+string keyname="single_tap"+finger_count+"f";
+if (this.tap_map.get(keyname, key))
+{
+if (simulate_key_down(key))
+{
+key_codes.insert_last(key);
+return true;
+}
+}
+int[] keys;
+if (this.tap_map.get(keyname, keys))
+{
+if (simulate_keys_down(keys))
+{
+key_codes=keys;
+return true;
+}
+}
+return false;
+}
+void queue_release(int[] &in keys)
+{
+if (has_pending_release and pending_release_keys.length()>0)
+simulate_keys_up(pending_release_keys);
+pending_release_keys=keys;
+has_pending_release=true;
+pending_release_timer.restart();
+}
+void process_pending_releases()
+{
+if (has_pending_release and pending_release_timer.elapsed>=40)
+{
+simulate_keys_up(pending_release_keys);
+pending_release_keys.resize(0);
+has_pending_release=false;
+}
+}
+void on_released_finger(touch_screen_finger@ finger)
+{
+if (@finger == null)
+return;
+if (!finger.has_swiped and single_tap_guard.elapsed>=50)
+{
+int[] keycodes;
+uint finger_count=this.parent.finger_map.get_size();
+if (finger_count<1)
+finger_count=1;
+if (attempt_single_tap(finger_count, keycodes))
+{
+finger.last_keys_pressed=keycodes;
+queue_release(keycodes);
+single_tap_guard.restart();
+return;
+}
+single_tap_guard.restart();
+}
+touch_keyboard_interface::on_released_finger(finger);
+}
+}
 void main()
 {
 show_window("Bop It Engine");
-touch_keyboard_interface touchkeys(touch, {
+single_tap_touch_keyboard_interface touchkeys(touch, {
 {"swipe_left1f", KEY_LEFT},
 {"swipe_right1f", KEY_RIGHT},
 {"swipe_up1f", KEY_UP},
@@ -37,6 +111,7 @@ while(true)
 wait(5);
 b.loop();
 touch.monitor();
+touchkeys.process_pending_releases();
 if (key_pressed(KEY_TAB))
 {
 bopit_index++;

--- a/bop.nvgt
+++ b/bop.nvgt
@@ -8,84 +8,10 @@
 int bopit_index=0;
 bopit@[] bopits(0);
 touch_gesture_manager touch;
-class single_tap_touch_keyboard_interface : touch_keyboard_interface
-{
-dictionary tap_map;
-timer single_tap_guard;
-timer pending_release_timer;
-int[] pending_release_keys;
-bool has_pending_release=false;
-single_tap_touch_keyboard_interface(touch_gesture_manager@ parent, dictionary@ map, float minx = TOUCH_UNCOORDINATED, float maxx = TOUCH_UNCOORDINATED, float miny = TOUCH_UNCOORDINATED, float maxy = TOUCH_UNCOORDINATED)
-{
-super(parent, map, minx, maxx, miny, maxy);
-this.tap_map=map;
-}
-bool attempt_single_tap(uint finger_count, int[] &out key_codes)
-{
-int key;
-string keyname="single_tap"+finger_count+"f";
-if (this.tap_map.get(keyname, key))
-{
-if (simulate_key_down(key))
-{
-key_codes.insert_last(key);
-return true;
-}
-}
-int[] keys;
-if (this.tap_map.get(keyname, keys))
-{
-if (simulate_keys_down(keys))
-{
-key_codes=keys;
-return true;
-}
-}
-return false;
-}
-void queue_release(int[] &in keys)
-{
-if (has_pending_release and pending_release_keys.length()>0)
-simulate_keys_up(pending_release_keys);
-pending_release_keys=keys;
-has_pending_release=true;
-pending_release_timer.restart();
-}
-void process_pending_releases()
-{
-if (has_pending_release and pending_release_timer.elapsed>=40)
-{
-simulate_keys_up(pending_release_keys);
-pending_release_keys.resize(0);
-has_pending_release=false;
-}
-}
-void on_released_finger(touch_screen_finger@ finger)
-{
-if (@finger == null)
-return;
-if (!finger.has_swiped and single_tap_guard.elapsed>=50)
-{
-int[] keycodes;
-uint finger_count=this.parent.finger_map.get_size();
-if (finger_count<1)
-finger_count=1;
-if (attempt_single_tap(finger_count, keycodes))
-{
-finger.last_keys_pressed=keycodes;
-queue_release(keycodes);
-single_tap_guard.restart();
-return;
-}
-single_tap_guard.restart();
-}
-touch_keyboard_interface::on_released_finger(finger);
-}
-}
 void main()
 {
 show_window("Bop It Engine");
-single_tap_touch_keyboard_interface touchkeys(touch, {
+touch_keyboard_interface touchkeys(touch, {
 {"swipe_left1f", KEY_LEFT},
 {"swipe_right1f", KEY_RIGHT},
 {"swipe_up1f", KEY_UP},
@@ -111,7 +37,6 @@ while(true)
 wait(5);
 b.loop();
 touch.monitor();
-touchkeys.process_pending_releases();
 if (key_pressed(KEY_TAB))
 {
 bopit_index++;

--- a/includes/beat.nvgt
+++ b/includes/beat.nvgt
@@ -71,7 +71,10 @@ if (beats.exists(name))
 {
 string b;
 beats.get(name,b);
-string[] data=b.split("\r\n",false);
+// Android builds may normalize multiline string endings to \n only.
+b=b.replace("\r\n","\n");
+b=b.replace("\r","\n");
+string[] data=b.split("\n",false);
 for (uint i=0; i<data.length(); i++)
 {
 string[] data2=data[i].split(":",true);
@@ -83,7 +86,13 @@ add_segment(beat_segment(@h,parse_int(data2[1]),0,true));
 else if (data2.length()==3)
 add_segment(beat_segment(@h,parse_int(data2[1]),parse_int(data2[2]),true));
 else if (data2.length()==4)
-add_segment(beat_segment(@h,parse_int(data2[1]),parse_int(data2[2]),data[2]=="true"?true:false));
+add_segment(beat_segment(@h,parse_int(data2[1]),parse_int(data2[2]),data2[3]=="true"?true:false));
+}
+if (segments.length()==0)
+{
+playing=false;
+index=0;
+return false;
 }
 this.index=-1;
 this.playing=true;

--- a/includes/extreme2.nvgt
+++ b/includes/extreme2.nvgt
@@ -18,20 +18,43 @@ void add_sounds()
 add_sounds({"1", "1b", "1c", "2", "2b", "2c", "3", "3b", "3c", "4", "4b", "4c", "5", "5b", "5c", "ouch", "passit", "out", "score", "hs", "vb", "bb", "solo", "bad1", "bad2", "bad3", "bad4", "bad5", "bad6", "bad7", "good1", "good2", "good3"});
 b.add_sounds({"1", "1b", "1c", "2", "2b", "2c", "3", "3b", "3c", "4", "4b", "4c", "5", "5b", "5c", "passit", "pass2_1", "pass2_2", "pass2_3", "pass2_4"});
 string[] drumsounds=find_files("sounds/extreme2/beat*.flac");
-for(uint i=0; i<drumsounds.length(); i++) {
-drumsounds[i]=drumsounds[i].slice(0,drumsounds[i].find_last(".flac"));
+normalize_sound_names(drumsounds);
+if (drumsounds.length()==0)
+{
+drumsounds={
+"beat1hat", "beat1hat2", "beat1kick", "beat1kick2", "beat1kick3", "beat1kick4", "beat1kick5", "beat1kick6",
+"beat1perc", "beat1perc2", "beat1perc3", "beat1snare", "beat1snare2",
+"beat2bell", "beat2kick", "beat2kick2", "beat2kick3", "beat2kick4", "beat2snare", "beat2snare2", "beat2snare3", "beat2unknown",
+"beat3bell", "beat3bongo", "beat3bongo2", "beat3bongobell", "beat3hat", "beat3hatbell", "beat3hatc",
+"beat3kick", "beat3kick2", "beat3kick3", "beat3kick4", "beat3perc", "beat3percbell", "beat3percbell2", "beat3percbell3",
+"beat3snare", "beat3snare2",
+"beat4clap", "beat4hat", "beat4kick", "beat4kicksnare", "beat4snare", "beat4snare2", "beat_spacer"
+};
 }
 b.add_sounds(drumsounds);
 string[] passtones1=find_files("sounds/extreme2/pass1*.flac");
-for(uint i=0; i<passtones1.length(); i++) {
-passtones1[i]=passtones1[i].slice(0,passtones1[i].find_last(".flac"));
-}
+normalize_sound_names(passtones1);
+if (passtones1.length()==0)
+passtones1={"pass1_1", "pass1_2", "pass1_3", "pass1_4", "pass1_5", "pass1_6", "pass1_7", "pass1_8", "pass1_9", "pass1_10"};
 b.add_sounds(passtones1);
-string[] passtones2=find_files("sounds/extreme2/pass1*.flac");
-for(uint i=0; i<passtones2.length(); i++) {
-passtones2[i]=passtones2[i].slice(0,passtones2[i].find_last(".flac"));
-}
+string[] passtones2=find_files("sounds/extreme2/pass2*.flac");
+normalize_sound_names(passtones2);
+if (passtones2.length()==0)
+passtones2={"pass2_1", "pass2_2", "pass2_3", "pass2_4"};
 b.add_sounds(passtones2);
+}
+void normalize_sound_names(string[]@ sound_names)
+{
+for(uint i=0; i<sound_names.length(); i++)
+{
+sound_names[i]=sound_names[i].replace("\\","/");
+int slash=sound_names[i].find_last("/");
+if (slash>-1)
+sound_names[i]=sound_names[i].substr(slash+1);
+int ext=sound_names[i].find_last(".flac");
+if (ext>-1)
+sound_names[i]=sound_names[i].slice(0,ext);
+}
 }
 void add_commands()
 {


### PR DESCRIPTION
## Summary
- fix `bopit_extreme2` dynamic sound loading on Android by normalizing discovered filenames and adding deterministic fallback beat/pass sample lists when `find_files` returns no packaged assets
- harden beat parsing by supporting both `\r\n` and `\n` line endings, fix 4-part segment boolean parsing, and guard against empty beat segment playback
- add a custom touch keyboard interface in `bop.nvgt` that emits `single_tap{N}f` events on finger release so touchscreen BopIt taps map to `KEY_DOWN` reliably

## Testing
- `~/Downloads/nvgt_0.90.0_dev/nvgt -I ~/Downloads/nvgt_0.90.0_dev/include -c -p android bop.nvgt` (build + install succeeded)
- `./linux.sh build` (release build succeeded)
- runtime sanity on device via `adb` (launch + tap/swipe + key events; no crash/ANR in logcat)
